### PR TITLE
[debian/rules]: Add autoreconf_clean to configure

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 	   exit 1; \
 	fi
 	
+	dh_autoreconf_clean
 	dh_autoreconf
 	dh_auto_configure -- \
 		--enable-exampledir=/usr/share/doc/quagga/examples/ \


### PR DESCRIPTION
When running dpkg-buildpackage with -nc option (no-clean), build fails
with error message saying that autoreconf cannot run twice. In order to
avoid this, we run autoreconf_clean prior to it.

Signed-off-by: marian-pritsak <marianp@mellanox.com>