### PR TITLE
[bgpd]: After fast-reboot procedure enable Forwarding State flag in Graceful restart capability

### DIFF
--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -119,7 +119,7 @@ int vty_port = BGP_VTY_PORT;
 char *vty_addr = NULL;
 
 /* BGP Graceful restart Forwarding State (F) bit state */
-unsigned char bgp_gr_f_bit = 0x00;
+extern unsigned char bgp_gr_f_bit;
 
 /* privileges */
 static zebra_capabilities_t _caps_p [] =  

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -67,6 +67,7 @@ static const struct option longopts[] =
   { "group",       required_argument, NULL, 'g'},
   { "version",     no_argument,       NULL, 'v'},
   { "dryrun",      no_argument,       NULL, 'C'},
+  { "f_bit",       no_argument,       NULL, 'F'},
   { "help",        no_argument,       NULL, 'h'},
   { 0 }
 };
@@ -117,6 +118,9 @@ static const char *pid_file = PATH_BGPD_PID;
 int vty_port = BGP_VTY_PORT;
 char *vty_addr = NULL;
 
+/* BGP Graceful restart Forwarding State (F) bit state */
+unsigned char bgp_gr_f_bit = 0x00;
+
 /* privileges */
 static zebra_capabilities_t _caps_p [] =  
 {
@@ -164,6 +168,7 @@ redistribution between different routing protocols.\n\n\
 -g, --group        Group to run as\n\
 -v, --version      Print program version\n\
 -C, --dryrun       Check configuration for validity and exit\n\
+-F, --f_bit        Set Forwarding State (F) bit for BGP graceful restart\n\
 -h, --help         Display this help and exit\n\
 \n\
 Report bugs to %s\n", progname, ZEBRA_BUG_ADDRESS);
@@ -345,7 +350,7 @@ main (int argc, char **argv)
   /* Command line argument treatment. */
   while (1) 
     {
-      opt = getopt_long (argc, argv, "df:i:z:hp:l:A:P:rnu:g:vC", longopts, 0);
+      opt = getopt_long (argc, argv, "df:i:z:hp:l:A:P:rnu:g:vCF", longopts, 0);
     
       if (opt == EOF)
 	break;
@@ -410,6 +415,9 @@ main (int argc, char **argv)
 	case 'C':
 	  dryrun = 1;
 	  break;
+        case 'F':
+          bgp_gr_f_bit = 0x80;
+          break;
 	case 'h':
 	  usage (progname, 0);
 	  break;

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -37,7 +37,8 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_aspath.h"
 #include "bgpd/bgp_vty.h"
 
-extern unsigned char bgp_gr_f_bit;
+/* BGP Graceful restart Forwarding State (F) bit state */
+unsigned char bgp_gr_f_bit = 0x00;
 
 /* BGP-4 Multiprotocol Extentions lead us to the complex world. We can
    negotiate remote peer supports extentions or not. But if

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -37,6 +37,8 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_aspath.h"
 #include "bgpd/bgp_vty.h"
 
+extern unsigned char bgp_gr_f_bit;
+
 /* BGP-4 Multiprotocol Extentions lead us to the complex world. We can
    negotiate remote peer supports extentions or not. But if
    remote-peer doesn't supports negotiation process itself.  We would
@@ -1049,7 +1051,7 @@ bgp_open_capability (struct stream *s, struct peer *peer)
             {
               stream_putw (s, afi);
               stream_putc (s, safi);
-              stream_putc (s, 0); //Forwarding is not retained as of now.
+              stream_putc (s, bgp_gr_f_bit); /* report retained state by request */
             }
     }
 

--- a/debian/quagga.init.d
+++ b/debian/quagga.init.d
@@ -79,6 +79,13 @@ start()
         echo -n " $1"
         if ! check_daemon $1; then return; fi
 
+        EXTRA_DAEMON_FLAGS=""
+
+        if [ "$1" = "bgpd" -a "$FAST_REBOOT" = "yes" ];
+        then
+            EXTRA_DAEMON_FLAGS+="-F "
+        fi
+
         if [ "$1" = "watchquagga" ]; then
             start-stop-daemon \
                 --oknodo \
@@ -93,6 +100,7 @@ start()
                 --pidfile=`pidfile $1` \
                 --exec "$D_PATH/$1" \
                 -- \
+                EXTRA_DAEMON_FLAGS \
                 `eval echo "$""$1""_options"`
         fi
 }
@@ -264,6 +272,16 @@ if [ ! -d /var/run/quagga ]; then
     chown quagga:quagga /var/run/quagga
     chmod 755 /var/run/quagga
 fi
+
+# Check Fast-Reboot case
+case "$(cat /proc/cmdline)" in
+  *fast-reboot*)
+     FAST_REBOOT='yes'
+    ;;
+  *)
+     FAST_REBOOT='no'
+    ;;
+esac
 
 case "$1" in
     start)

--- a/debian/quagga.init.d
+++ b/debian/quagga.init.d
@@ -83,7 +83,7 @@ start()
 
         if [ "$1" = "bgpd" -a "$FAST_REBOOT" = "yes" ];
         then
-            EXTRA_DAEMON_FLAGS+="-F "
+            EXTRA_DAEMON_FLAGS+="-F"
         fi
 
         if [ "$1" = "watchquagga" ]; then
@@ -100,8 +100,8 @@ start()
                 --pidfile=`pidfile $1` \
                 --exec "$D_PATH/$1" \
                 -- \
-                EXTRA_DAEMON_FLAGS \
-                `eval echo "$""$1""_options"`
+                `eval echo "$""$1""_options"` \
+                "$EXTRA_DAEMON_FLAGS"
         fi
 }
 


### PR DESCRIPTION
Otherwise the preserved bgp routes on remote side will be removed after our side sends a bgp open message to the remote side.