### PR TITLE
ignore nexthop attribute when NLRI is present

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2045,7 +2045,9 @@ bgp_attr_parse (struct peer *peer, struct attr *attr, bgp_size_t size,
       && !CHECK_FLAG (attr->flag, ATTR_FLAG_BIT (BGP_ATTR_MP_REACH_NLRI)))
     {
 
-      if (IPV4_NET0 (attr->nexthop.s_addr) || IPV4_NET127 (attr->nexthop.s_addr) || IPV4_CLASS_DE (attr->nexthop.s_addr))
+      in_addr_t nexthop_h;
+      nexthop_h = ntohl(attr->nexthop.s_addr);
+      if (IPV4_NET0 (nexthop_h) || IPV4_NET127 (nexthop_h) || IPV4_CLASS_DE (nexthop_h))
         {
           char buf[INET_ADDRSTRLEN];
           inet_ntop (AF_INET, &attr->nexthop.s_addr, buf, INET_ADDRSTRLEN);

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -1087,7 +1087,7 @@ bgp_attr_nexthop (struct bgp_attr_parser_args *args)
   struct attr *const attr = args->attr;
   const bgp_size_t length = args->length;
   
-  in_addr_t nexthop_h, nexthop_n;
+  in_addr_t nexthop_n;
 
   /* Check nexthop attribute length. */
   if (length != 4)
@@ -1101,7 +1101,6 @@ bgp_attr_nexthop (struct bgp_attr_parser_args *args)
     }
 
   nexthop_n = stream_get_ipv4 (peer->ibuf);
-  nexthop_h = ntohl (nexthop_n);
   attr->nexthop.s_addr = nexthop_n;
   attr->flag |= ATTR_FLAG_BIT (BGP_ATTR_NEXT_HOP);
 


### PR DESCRIPTION
According to section 1.3 of RFC2858, an UPDATE message that carries no NLRI,
other than the one encoded in the MP_REACH_NLRI attribute, should not carry
the NEXT_HOP attribute. If such a message contains the NEXT_HOP attribute,
the BGP speaker that receives the message should ignore this attribute.