### PR TITLE
Auto-completion, help (?), cmd navigation (up/down arrows) not working in vtysh on host system.

### DIFF
--- a/debian/quagga.postinst
+++ b/debian/quagga.postinst
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+rm /etc/alternatives/pager
+ln -s /bin/cat /etc/alternatives/pager
+
 if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
 ${DEBIAN_SCRIPT_TRACE:+ echo "#42#DEBUG# RUNNING $0 $*"}
 


### PR DESCRIPTION
This fix complements the fix in https://github.com/Azure/sonic-buildimage/pull/1124