### PR TITLE
Fix the issue with IPv6 multipath

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -111,28 +111,45 @@ bgp_info_nexthop_cmp (struct bgp_info *bi1, struct bgp_info *bi2)
 
   compare = IPV4_ADDR_CMP (&bi1->attr->nexthop, &bi2->attr->nexthop);
 
-  if (!compare && ae1 && ae2 && (ae1->mp_nexthop_len == ae2->mp_nexthop_len))
+  if (!compare && ae1 && ae2)
     {
-      switch (ae1->mp_nexthop_len)
+      if (ae1->mp_nexthop_len == ae2->mp_nexthop_len)
         {
-        case 4:
-        case 12:
-          compare = IPV4_ADDR_CMP (&ae1->mp_nexthop_global_in,
-                                   &ae2->mp_nexthop_global_in);
-          break;
-#ifdef HAVE_IPV6
-        case 16:
-          compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_global,
-                                   &ae2->mp_nexthop_global);
-          break;
-        case 32:
+          switch (ae1->mp_nexthop_len)
+            {
+            case 4:
+            case 12:
+              compare = IPV4_ADDR_CMP (&ae1->mp_nexthop_global_in,
+                                       &ae2->mp_nexthop_global_in);
+              break;
+            case 16:
+              compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_global,
+                                       &ae2->mp_nexthop_global);
+              break;
+            case 32:
+              compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_global,
+                                       &ae2->mp_nexthop_global);
+              if (!compare)
+                compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_local,
+                                         &ae2->mp_nexthop_local);
+              break;
+            }
+        }
+
+      /* This can happen if one IPv6 peer sends you global and link-local
+       * nexthops but another IPv6 peer only sends you global
+       */
+      else if (ae1->mp_nexthop_len == 16 || ae1->mp_nexthop_len == 32)
+        {
           compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_global,
                                    &ae2->mp_nexthop_global);
           if (!compare)
-            compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_local,
-                                     &ae2->mp_nexthop_local);
-          break;
-#endif /* HAVE_IPV6 */
+            {
+              if (ae1->mp_nexthop_len < ae2->mp_nexthop_len)
+                compare = -1;
+              else
+                compare = 1;
+            }
         }
     }
 
@@ -401,7 +418,7 @@ bgp_info_mpath_update (struct bgp_node *rn, struct bgp_info *new_best,
   struct listnode *mp_node, *mp_next_node;
   struct bgp_info *cur_mpath, *new_mpath, *next_mpath, *prev_mpath;
   int mpath_changed, debug;
-  char pfx_buf[INET_ADDRSTRLEN], nh_buf[2][INET_ADDRSTRLEN];
+  char pfx_buf[INET6_ADDRSTRLEN], nh_buf[2][INET6_ADDRSTRLEN];
 
   mpath_changed = 0;
   maxpaths = BGP_DEFAULT_MAXPATHS;

--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -122,6 +122,7 @@ bgp_info_nexthop_cmp (struct bgp_info *bi1, struct bgp_info *bi2)
               compare = IPV4_ADDR_CMP (&ae1->mp_nexthop_global_in,
                                        &ae2->mp_nexthop_global_in);
               break;
+#ifdef HAVE_IPV6
             case 16:
               compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_global,
                                        &ae2->mp_nexthop_global);
@@ -133,9 +134,11 @@ bgp_info_nexthop_cmp (struct bgp_info *bi1, struct bgp_info *bi2)
                 compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_local,
                                          &ae2->mp_nexthop_local);
               break;
+#endif /* HAVE_IPV6 */
             }
         }
 
+#ifdef HAVE_IPV6
       /* This can happen if one IPv6 peer sends you global and link-local
        * nexthops but another IPv6 peer only sends you global
        */
@@ -151,6 +154,7 @@ bgp_info_nexthop_cmp (struct bgp_info *bi1, struct bgp_info *bi2)
                 compare = 1;
             }
         }
+#endif /* HAVE_IPV6 */
     }
 
   return compare;


### PR DESCRIPTION
Paths with global and link-local nexthops should be considered for multipath

Based on https://github.com/Quagga/quagga/commit/d8c5f27777051b3ea32f8b5979ecd9bb7b9475b9

Without the patch if we have a route which has both global and local nexthop addresses this route will not be considered for multipath.