### PR TITLE
Add support of custom ip dscp value for bgp sessions

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -420,10 +420,10 @@ bgp_connect (struct peer *peer)
   if (bgpd_privs.change (ZPRIVS_RAISE))
     zlog_err ("%s: could not raise privs", __func__);
   if (sockunion_family (&peer->su) == AF_INET)
-    setsockopt_ipv4_tos (peer->fd, IPTOS_PREC_INTERNETCONTROL);
+    setsockopt_ipv4_tos (peer->fd, peer->bgp->tcp_dscp);
 # ifdef HAVE_IPV6
   else if (sockunion_family (&peer->su) == AF_INET6)
-    setsockopt_ipv6_tclass (peer->fd, IPTOS_PREC_INTERNETCONTROL);
+    setsockopt_ipv6_tclass (peer->fd, peer->bgp->tcp_dscp);
 # endif
   if (bgpd_privs.change (ZPRIVS_LOWER))
     zlog_err ("%s: could not lower privs", __func__);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -437,6 +437,45 @@ ALIAS (no_router_bgp,
        "BGP view\n"
        "view name\n")
 
+/* bgp session-dscp */
+
+DEFUN (bgp_session_dscp,
+       bgp_session_dscp_cmd,
+       "bgp session-dscp DSCP",
+        BGP_STR
+       "Override default (C0) bgp session ip dscp field\n"
+       "Manually configured dscp parameter\n")
+{
+  struct bgp *bgp;
+
+  u_char value = (u_char)strtol(argv[0], NULL, 16);
+  if ((value == 0 && errno == EINVAL) || (value > 0x3f))
+  {
+    vty_out (vty, "%% Malformed bgp session-dscp parameter%s", VTY_NEWLINE);
+    return CMD_WARNING;
+  }
+
+  bgp = vty->index;
+  bgp->tcp_dscp = value << 2;
+
+  return CMD_SUCCESS;
+}
+
+DEFUN (no_bgp_session_dscp,
+       no_bgp_session_dscp_cmd,
+       "no bgp session-dscp",
+       NO_STR
+       BGP_STR
+       "Override default (C0) bgp session ip dscp field\n")
+{
+  struct bgp *bgp;
+
+  bgp = vty->index;
+  bgp->tcp_dscp = IPTOS_PREC_INTERNETCONTROL;
+
+  return CMD_SUCCESS;
+}
+
 /* BGP router-id.  */
 
 DEFUN (bgp_router_id,
@@ -9645,6 +9684,10 @@ bgp_vty_init (void)
   /* "no router bgp" commands. */
   install_element (CONFIG_NODE, &no_router_bgp_cmd);
   install_element (CONFIG_NODE, &no_router_bgp_view_cmd);
+
+  /* "bgp session-dscp command */
+  install_element (BGP_NODE, &bgp_session_dscp_cmd);
+  install_element (BGP_NODE, &no_bgp_session_dscp_cmd);
 
   /* "bgp router-id" commands. */
   install_element (BGP_NODE, &bgp_router_id_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -2104,6 +2104,7 @@ bgp_create (as_t *as, const char *name)
   bgp->stalepath_time = BGP_DEFAULT_STALEPATH_TIME;
   bgp->dynamic_neighbors_limit = BGP_DYNAMIC_NEIGHBORS_LIMIT_DEFAULT;
   bgp->dynamic_neighbors_count = 0;
+  bgp->tcp_dscp = IPTOS_PREC_INTERNETCONTROL;
 
   bgp->as = *as;
 
@@ -5628,6 +5629,11 @@ bgp_config_write (struct vty *vty)
       /* BGP fast-external-failover. */
       if (CHECK_FLAG (bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER))
 	vty_out (vty, " no bgp fast-external-failover%s", VTY_NEWLINE); 
+
+      /* BGP session-dscp */
+      if (bgp->tcp_dscp != IPTOS_PREC_INTERNETCONTROL)
+	vty_out (vty, " bgp session-dscp %02X%s", (bgp->tcp_dscp >> 2),
+		 VTY_NEWLINE);
 
       /* BGP router ID. */
       if (CHECK_FLAG (bgp->config, BGP_CONFIG_ROUTER_ID))

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -223,6 +223,8 @@ struct bgp
     u_int16_t maxpaths_ebgp;
     u_int16_t maxpaths_ibgp;
   } maxpaths[AFI_MAX][SAFI_MAX];
+
+  u_char tcp_dscp;
 };
 
 /* BGP peer-group support. */


### PR DESCRIPTION
Add 'bgp session-dscp' parameter for router bgp N section of quagga.
This parameter allows us to define custom dscp bits for ipv4 and ipv6 bgp sessions.
By default this parameter set to 0x40 (0xc0 in the packet).