### PR TITLE
[security] Fix infinite loop on certain invalid OPEN messages (Quagga-2018-1975)

### DIFF
--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -2243,7 +2243,8 @@ bgp_capability_msg_parse (struct peer *peer, u_char *pnt, bgp_size_t length)
 
   end = pnt + length;
 
-  while (pnt < end)
+  /* XXX: Streamify this */
+  for (; pnt < end; pnt += hdr->length + 3)
     {      
       /* We need at least action, capability code and capability length. */
       if (pnt + 3 > end)
@@ -2331,7 +2332,6 @@ bgp_capability_msg_parse (struct peer *peer, u_char *pnt, bgp_size_t length)
           zlog_warn ("%s unrecognized capability code: %d - ignored",
                      peer->host, hdr->code);
         }
-      pnt += hdr->length + 3;
     }
   return 0;
 }


### PR DESCRIPTION
Subject: bgpd/security: fix infinite loop on certain invalid OPEN messages

Security issue: Quagga-2018-1975
See: https://www.quagga.net/security/Quagga-2018-1975.txt

* bgpd/bgp_packet.c: (bgp_capability_msg_parse) capability parser can infinite
  loop due to checks that issue 'continue' without bumping the input
  pointer.