### PR TITLE
Don't create duplicate dynamic BGP sessions.

### DIFF
--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -220,6 +220,22 @@ bgp_accept (struct thread *thread)
 
   peer1 = peer_lookup (NULL, &su);
 
+
+  /*
+   * Don't allow to setup a static session for the peers, which were created as DYNAMIC.
+     It isn't supported to have a static session in dynamic range
+   */
+
+  if (peer1 && peer_dynamic_neighbor(peer1))
+  {
+      zlog_debug ("[Event] Close connection from %s. We already have such connection created as DYNAMIC.",
+		   inet_sutop (&su, buf));
+
+      close (bgp_sock);
+
+      return -1;
+  }
+
   /*
    * Close incoming connection from directly connected EBGP peers until we receive
      interface_up message from zebra

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -222,13 +222,12 @@ bgp_accept (struct thread *thread)
 
 
   /*
-   * Don't allow to setup a static session for the peers, which were created as DYNAMIC.
-     It isn't supported to have a static session in dynamic range
+   * Close incoming connection from the same dynamic peer
    */
 
   if (peer1 && peer_dynamic_neighbor(peer1))
   {
-      zlog_debug ("[Event] Close connection from %s. We already have such connection created as DYNAMIC.",
+      zlog_debug ("[Event] Close connection from %s. We already have this dynamic connection",
 		   inet_sutop (&su, buf));
 
       close (bgp_sock);


### PR DESCRIPTION
Sometimes dynamic BGP peers setup another TCP connection despite they already have one.

When quagga receives second tcp connection from the same dynamic peer, quagga pick up struct peer structure for the dynamic peer, instead of creating of the new one (because it's dynamic peer, not static). 
So quagga has two tcp connections, but they share the same peer structure.
Later quagga realize that it already has bgp session is created for the peer, and quagga removes the peer structure, but the first connection is still active. The first connection tries to use the removed peer structure and bgpd crashes.