### PR TITLE
Reduce the retry time for IPV6 connections to avoid reprogramming IPv…

### DIFF
--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -727,15 +727,9 @@ bgp_start (struct peer *peer)
     afi = AFI_IP;
   else if (sockunion_family (&peer->su) == AF_INET6)
     afi = AFI_IP6;
-  else
-    {
-      if (BGP_DEBUG (fsm, FSM))
-        plog_err (peer->log, "%s [FSM] Unsupported address family type",
-                  peer->host);
-      return -1;
-    }
 
-  if (peer->sort == BGP_PEER_EBGP && peer->ttl == 1
+  if ((afi == AFI_IP || afi == AFI_IP6)
+      && peer->sort == BGP_PEER_EBGP && peer->ttl == 1
       && ! bgp_addr_onlink (afi, &peer->su))
     {
       if (BGP_DEBUG (fsm, FSM))

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -710,6 +710,7 @@ int
 bgp_start (struct peer *peer)
 {
   int status;
+  afi_t afi;
 
   if (BGP_PEER_START_SUPPRESSED (peer))
     {
@@ -722,9 +723,13 @@ bgp_start (struct peer *peer)
   /*
    * Don't connect if we haven't received interface_up message from zebra
    */
+  if (sockunion_family (&peer->su) == AF_INET)
+    afi = AFI_IP;
+  else if (sockunion_family (&peer->su) == AF_INET6)
+    afi = AFI_IP6;
+
   if (peer->sort == BGP_PEER_EBGP && peer->ttl == 1
-      && sockunion_family (&peer->su) == AF_INET
-      && ! bgp_addr_onlink_v4 (&peer->su.sin.sin_addr))
+      && ! bgp_addr_onlink (afi, &peer->su))
     {
       if (BGP_DEBUG (fsm, FSM))
         plog_warn (peer->log, "%s [FSM] Delay connection to the remote peer. The interface isn't ready yet",

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -727,6 +727,13 @@ bgp_start (struct peer *peer)
     afi = AFI_IP;
   else if (sockunion_family (&peer->su) == AF_INET6)
     afi = AFI_IP6;
+  else
+    {
+      if (BGP_DEBUG (fsm, FSM))
+        plog_err (peer->log, "%s [FSM] Unsupported address family type",
+                  peer->host);
+      return -1;
+    }
 
   if (peer->sort == BGP_PEER_EBGP && peer->ttl == 1
       && ! bgp_addr_onlink (afi, &peer->su))

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -710,7 +710,7 @@ int
 bgp_start (struct peer *peer)
 {
   int status;
-  afi_t afi;
+  afi_t afi = AFI_UNSPEC;
 
   if (BGP_PEER_START_SUPPRESSED (peer))
     {
@@ -728,8 +728,7 @@ bgp_start (struct peer *peer)
   else if (sockunion_family (&peer->su) == AF_INET6)
     afi = AFI_IP6;
 
-  if ((afi == AFI_IP || afi == AFI_IP6)
-      && peer->sort == BGP_PEER_EBGP && peer->ttl == 1
+  if (afi != AFI_UNSPEC && peer->sort == BGP_PEER_EBGP && peer->ttl == 1
       && ! bgp_addr_onlink (afi, &peer->su))
     {
       if (BGP_DEBUG (fsm, FSM))

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -245,6 +245,12 @@ bgp_accept (struct thread *thread)
     afi = AFI_IP;
   else if (sockunion_family (&su) == AF_INET6)
     afi = AFI_IP6;
+  else
+    {
+      zlog_err ("[Error] Unsupported address family type %d", sockunion_family (&su));
+      close (bgp_sock);
+      return -1;
+    }
 
   if (peer1 && peer1->sort == BGP_PEER_EBGP && peer1->ttl == 1
       && ! bgp_addr_onlink (afi, &su))

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -200,7 +200,7 @@ bgp_accept (struct thread *thread)
   struct peer *peer;
   struct peer *peer1;
   char buf[SU_ADDRSTRLEN];
-  afi_t afi;
+  afi_t afi = AFI_UNSPEC;
 
   /* Register accept thread. */
   accept_sock = THREAD_FD (thread);
@@ -246,8 +246,7 @@ bgp_accept (struct thread *thread)
   else if (sockunion_family (&su) == AF_INET6)
     afi = AFI_IP6;
 
-  if ((afi == AFI_IP || afi == AFI_IP6)
-      && peer1 && peer1->sort == BGP_PEER_EBGP && peer1->ttl == 1
+  if (afi != AFI_UNSPEC && peer1 && peer1->sort == BGP_PEER_EBGP && peer1->ttl == 1
       && ! bgp_addr_onlink (afi, &su))
     {
       zlog_debug ("[Event] Close connection from %s. The interface isn't ready yet",

--- a/bgpd/bgp_network.c
+++ b/bgpd/bgp_network.c
@@ -245,14 +245,9 @@ bgp_accept (struct thread *thread)
     afi = AFI_IP;
   else if (sockunion_family (&su) == AF_INET6)
     afi = AFI_IP6;
-  else
-    {
-      zlog_err ("[Error] Unsupported address family type %d", sockunion_family (&su));
-      close (bgp_sock);
-      return -1;
-    }
 
-  if (peer1 && peer1->sort == BGP_PEER_EBGP && peer1->ttl == 1
+  if ((afi == AFI_IP || afi == AFI_IP6)
+      && peer1 && peer1->sort == BGP_PEER_EBGP && peer1->ttl == 1
       && ! bgp_addr_onlink (afi, &su))
     {
       zlog_debug ("[Event] Close connection from %s. The interface isn't ready yet",

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -240,6 +240,40 @@ bgp_addr_onlink_v4 (struct in_addr *addr)
   return 0;
 }
 
+/* If the address exists on connected networks return 1. */
+int
+bgp_addr_onlink (afi_t afi, union sockunion *su)
+{
+  struct bgp_node *rn;
+
+  /* If zebra is not enabled return */
+  if (zlookup->sock < 0)
+    return 1;
+
+  /* Lookup the address is onlink or not. */
+  if (afi == AFI_IP)
+    {
+      rn = bgp_node_match_ipv4 (bgp_connected_table[AFI_IP], &su->sin.sin_addr);
+      if (rn)
+        {
+          bgp_unlock_node (rn);
+          return 1;
+        }
+    }
+#ifdef HAVE_IPV6
+  else if (afi == AFI_IP6)
+    {
+      rn = bgp_node_match_ipv6 (bgp_connected_table[AFI_IP6], &su->sin6.sin6_addr);
+      if (rn)
+        {
+          bgp_unlock_node (rn);
+          return 1;
+        }
+    }
+#endif /* HAVE_IPV6 */
+  return 0;
+}
+
 #ifdef HAVE_IPV6
 /* Check specified next-hop is reachable or not. */
 static int

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -219,27 +219,6 @@ bgp_nexthop_onlink (afi_t afi, struct attr *attr)
   return 0;
 }
 
-/* If the IPv4 address exists on connected networks return 1. */
-int
-bgp_addr_onlink_v4 (struct in_addr *addr)
-{
-  struct bgp_node *rn;
-
-  /* If zebra is not enabled return */
-  if (zlookup->sock < 0)
-    return 1;
-
-  /* Lookup the address is onlink or not. */
-  rn = bgp_node_match_ipv4 (bgp_connected_table[AFI_IP], addr);
-  if (rn)
-    {
-      bgp_unlock_node (rn);
-      return 1;
-    }
-
-  return 0;
-}
-
 /* If the address exists on connected networks return 1. */
 int
 bgp_addr_onlink (afi_t afi, union sockunion *su)

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -56,6 +56,7 @@ extern int bgp_multiaccess_check_v4 (struct in_addr, char *);
 extern int bgp_config_write_scan_time (struct vty *);
 extern int bgp_nexthop_onlink (afi_t, struct attr *);
 extern int bgp_addr_onlink_v4 (struct in_addr *);
+extern int bgp_addr_onlink (afi_t, union sockunion *);
 extern int bgp_nexthop_self (struct attr *);
 extern void bgp_address_init (void);
 

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -55,7 +55,6 @@ extern void bgp_connected_delete (struct connected *c);
 extern int bgp_multiaccess_check_v4 (struct in_addr, char *);
 extern int bgp_config_write_scan_time (struct vty *);
 extern int bgp_nexthop_onlink (afi_t, struct attr *);
-extern int bgp_addr_onlink_v4 (struct in_addr *);
 extern int bgp_addr_onlink (afi_t, union sockunion *);
 extern int bgp_nexthop_self (struct attr *);
 extern void bgp_address_init (void);

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -484,6 +484,7 @@ extern const char *zserv_command_string (unsigned int command);
 #define AFI_IP                    1
 #define AFI_IP6                   2
 #define AFI_MAX                   3
+#define AFI_UNSPEC                4
 
 /* Subsequent Address Family Identifier. */
 #define SAFI_UNICAST              1


### PR DESCRIPTION
…6 routes after warm reboot

Prior to the fix, once the start time for the IPV6 peer expires, peer moves from Idle to Connect state. When the connect fails, the connect timer (120s) kicks in. The next retry would happen only after the connect timer expires. This caused some IPv6 routes to be deleted by fpmsyncd during the warm reboot reconciliation since it hadn't received any info about these routes within that time. The routes were being received by fpmsyncd only after reconciliation was done.

The new changes are inline with what is done for IPv4 peer where once the start time expires, peer moves from Idle to connect state but if the interface address hasn't been received yet, the peer is again moved back to Idle state setting the start timer again. This allows more frequent retries.

Verified with the fix that IPv6 connection retry happens more frequently and hence fpmsyncd gets all the IPv6 routes before the reconciliation is complete. 