### PR TITLE
bgpd: Make bgp_info_cmp robust to paths that do not have su_remote info

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -552,6 +552,12 @@ bgp_info_cmp (struct bgp *bgp, struct bgp_info *new, struct bgp_info *exist,
   if (new_cluster > exist_cluster)
     return 0;
 
+  /* locally configured routes to advertise do not have su_remote */
+  if (new->peer->su_remote == NULL)
+    return 0;
+  if (exist->peer->su_remote == NULL)
+    return 1;
+
   /* 13. Neighbor address comparision. */
   ret = sockunion_cmp (new->peer->su_remote, exist->peer->su_remote);
 


### PR DESCRIPTION
Downport of
https://github.com/FRRouting/frr/commit/2820a01eed1c616d490ddbfd17793c19597459d1

My original su_remote == NULL check is not correct. It seems that

* bgp_route.c: (bgp_info_cmp) Some bgp_info is compared with su_remote=NULL
  and it's supposed to be perfectly legal.  E.g.  configured subnet announces
  ("network a.b.c.d/n"). Ensure bgp_info_cmp is robust if such a path gets
  as far as the neighbour address comparison step.

Downported because of following crash:
```
(gdb) bt
#0  0x00007f0fc73c0067 in __GI_raise (sig=sig@entry=0x6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007f0fc73c1448 in __GI_abort () at abort.c:89
#2  0x00007f0fc80b8774 in core_handler (signo=<optimized out>, siginfo=<optimized out>, context=<optimized out>) at sigevent.c:240
#3  <signal handler called>
#4  sockunion_cmp (su1=0x0, su2=0x0) at sockunion.c:730
#5  0x000055d010656012 in bgp_info_cmp (bgp=bgp@entry=0x55d011b74ec0, new=new@entry=0x55d0127ef510, exist=exist@entry=0x55d012966da0, paths_eq=paths_eq@entry=0x7fff833d62dc)
    at bgp_route.c:556
#6  0x000055d01065667a in bgp_best_selection (bgp=bgp@entry=0x55d011b74ec0, rn=rn@entry=0x55d011c2eed0, mpath_cfg=mpath_cfg@entry=0x55d011b75488, result=result@entry=0x7fff833d6360)
    at bgp_route.c:1536
#7  0x000055d010656a7e in bgp_process_main (wq=<optimized out>, data=<optimized out>) at bgp_route.c:1722
#8  0x00007f0fc80b9357 in work_queue_run (thread=0x7fff833d65a0) at workqueue.c:293
#9  0x00007f0fc80a0efc in thread_call (thread=0x7fff833d65a0) at thread.c:1252
#10 0x000055d01063acb0 in main (argc=0x4, argv=<optimized out>) at bgp_main.c:473
```