### PR TITLE
Deduce nexthop ifindex for ipv6 when ifindex points to 'lo'

### DIFF
--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -661,6 +661,18 @@ bgp_nexthop_set (union sockunion *local, union sockunion *remote,
   return ret;
 }
 
+static unsigned int
+bgp_zebra_ifindex_by_ipv6(struct in6_addr * addr)
+{
+  unsigned int ifindex = IFINDEX_INTERNAL;
+  struct interface *ifp;
+  ifp = if_lookup_by_ipv6(addr);
+  if (ifp)
+    return ifp->ifindex;
+  else
+    return ifindex;
+}
+
 void
 bgp_zebra_announce (struct prefix *p, struct bgp_info *info, struct bgp *bgp, safi_t safi)
 {
@@ -829,6 +841,22 @@ bgp_zebra_announce (struct prefix *p, struct bgp_info *info, struct bgp *bgp, sa
 	  else if (info->peer->nexthop.ifp)
 	    ifindex = info->peer->nexthop.ifp->ifindex;
 	}
+
+      if (strcmp (ifindex2ifname (ifindex), "lo") == 0)
+	{
+	  /* it doesn't make sense to send a traffic to lo interface */
+	  ifindex = bgp_zebra_ifindex_by_ipv6(nexthop);
+	  if (ifindex == IFINDEX_INTERNAL)
+	  {
+	    char prefix_buf[INET6_ADDRSTRLEN];
+	    char nexthop_buf[INET6_ADDRSTRLEN];
+	    zlog_err ("%s/%d Found nexthop ifindex pointed to 'lo'. Can't deduce nexthop ifindex for nexthop '%s'.",
+                inet_ntop(AF_INET6, &p->u.prefix6, prefix_buf, sizeof(prefix_buf)),
+                p->prefixlen,
+                inet_ntop(AF_INET6, nexthop, nexthop_buf, sizeof(nexthop_buf))); 
+	    return;
+	  }
+	}
       stream_put (bgp_nexthop_buf, &nexthop, sizeof (struct in6_addr *));
       stream_put (bgp_ifindices_buf, &ifindex, sizeof (unsigned int));
       valid_nh_count++;
@@ -882,7 +910,21 @@ bgp_zebra_announce (struct prefix *p, struct bgp_info *info, struct bgp *bgp, sa
 	    {
 	      continue;
 	    }
-
+ 	  if (strcmp (ifindex2ifname (ifindex), "lo") == 0)
+ 	    {
+	      /* it doesn't make sense to send a traffic to lo interface */
+	      ifindex = bgp_zebra_ifindex_by_ipv6(nexthop);
+	      if (ifindex == IFINDEX_INTERNAL)
+		{
+		  char prefix_buf[INET6_ADDRSTRLEN];
+		  char nexthop_buf[INET6_ADDRSTRLEN];
+		  zlog_err ("%s/%d Found nexthop ifindex pointed to 'lo'. Can't deduce nexthop ifindex for nexthop '%s'.",
+                        inet_ntop(AF_INET6, &p->u.prefix6, prefix_buf, sizeof(prefix_buf)),
+                        p->prefixlen,
+                        inet_ntop(AF_INET6, nexthop, nexthop_buf, sizeof(nexthop_buf)));
+		  continue;
+		}
+ 	    }
           stream_put (bgp_nexthop_buf, &nexthop, sizeof (struct in6_addr *));
           stream_put (bgp_ifindices_buf, &ifindex, sizeof (unsigned int));
           valid_nh_count++;

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -664,13 +664,12 @@ bgp_nexthop_set (union sockunion *local, union sockunion *remote,
 static unsigned int
 bgp_zebra_ifindex_by_ipv6(struct in6_addr * addr)
 {
-  unsigned int ifindex = IFINDEX_INTERNAL;
   struct interface *ifp;
   ifp = if_lookup_by_ipv6(addr);
   if (ifp)
     return ifp->ifindex;
   else
-    return ifindex;
+    return IFINDEX_INTERNAL;
 }
 
 void

--- a/bgpd/bgp_zebra.c
+++ b/bgpd/bgp_zebra.c
@@ -662,7 +662,7 @@ bgp_nexthop_set (union sockunion *local, union sockunion *remote,
 }
 
 static unsigned int
-bgp_zebra_ifindex_by_ipv6(struct in6_addr * addr)
+bgp_zebra_ifindex_by_ipv6(struct in6_addr *addr)
 {
   struct interface *ifp;
   ifp = if_lookup_by_ipv6(addr);
@@ -844,12 +844,12 @@ bgp_zebra_announce (struct prefix *p, struct bgp_info *info, struct bgp *bgp, sa
       if (strcmp (ifindex2ifname (ifindex), "lo") == 0)
 	{
 	  /* it doesn't make sense to send a traffic to lo interface */
-	  ifindex = bgp_zebra_ifindex_by_ipv6(nexthop);
+	  ifindex = bgp_zebra_ifindex_by_ipv6 (nexthop);
 	  if (ifindex == IFINDEX_INTERNAL)
 	  {
 	    char prefix_buf[INET6_ADDRSTRLEN];
 	    char nexthop_buf[INET6_ADDRSTRLEN];
-	    zlog_err ("%s/%d Found nexthop ifindex pointed to 'lo'. Can't deduce nexthop ifindex for nexthop '%s'.",
+	    zlog_err ("Prefix '%s/%d' nexthop '%s'. Can't find nexthop ifindex.",
                 inet_ntop(AF_INET6, &p->u.prefix6, prefix_buf, sizeof(prefix_buf)),
                 p->prefixlen,
                 inet_ntop(AF_INET6, nexthop, nexthop_buf, sizeof(nexthop_buf))); 
@@ -912,12 +912,12 @@ bgp_zebra_announce (struct prefix *p, struct bgp_info *info, struct bgp *bgp, sa
  	  if (strcmp (ifindex2ifname (ifindex), "lo") == 0)
  	    {
 	      /* it doesn't make sense to send a traffic to lo interface */
-	      ifindex = bgp_zebra_ifindex_by_ipv6(nexthop);
+	      ifindex = bgp_zebra_ifindex_by_ipv6 (nexthop);
 	      if (ifindex == IFINDEX_INTERNAL)
 		{
 		  char prefix_buf[INET6_ADDRSTRLEN];
 		  char nexthop_buf[INET6_ADDRSTRLEN];
-		  zlog_err ("%s/%d Found nexthop ifindex pointed to 'lo'. Can't deduce nexthop ifindex for nexthop '%s'.",
+		  zlog_err ("Prefix '%s/%d' nexthop '%s'. Can't find nexthop ifindex.",
                         inet_ntop(AF_INET6, &p->u.prefix6, prefix_buf, sizeof(prefix_buf)),
                         p->prefixlen,
                         inet_ntop(AF_INET6, nexthop, nexthop_buf, sizeof(nexthop_buf)));


### PR DESCRIPTION
When we have ipv4 bgp session with 'bgp x.x.x.x update-source y.y.y.y` where `y.y.y.y` assigned to 'lo' bgpd will use ifindex which points to 'lo' for ipv6 routes nexthops received through this ipv4 session.